### PR TITLE
Various Fixes

### DIFF
--- a/install-labkey.bash
+++ b/install-labkey.bash
@@ -277,7 +277,6 @@ function step_os_prereqs() {
     fi
     sudo yum update -y
     sudo yum install -y "$ADOPTOPENJDK_VERSION"
-
     ;;
 
   _centos)
@@ -298,7 +297,6 @@ function step_os_prereqs() {
       ) >"$NewFile"
     fi
     sudo yum install -y tomcat-native apr fontconfig "$ADOPTOPENJDK_VERSION"
-
     ;;
 
   _ubuntu)
@@ -312,7 +310,6 @@ function step_os_prereqs() {
 
     sudo apt-get update
     sudo apt-get install -y "$ADOPTOPENJDK_VERSION"
-
     ;;
 
   _*)


### PR DESCRIPTION
A number of minor things:
  - use ASCII escape sequences for color instead of `tput`, which isn't available by default on some platforms.
  - scoot `TOMCAT_SSL_*` vars and `POSTGRES_DB` default values up with the rest
  - add a failsafe check for systemctl
  - fix a copypasta in the "unsupported platform" message for adoptopenjdk
  - cleanup the `application.properties` file copied from the Dockerfile repo:
    - rm some N/A comments
    - rm some uneeded log level properties
    - change the access log location from the Dockerfile's `/tmp` to this script's `${LABKEY_INSTALL_HOME}/logs`

With these changes + what already in the integration test fixes PR, I think we're pretty close to being able to get this out the door!

We should talk about what we want to do with the unit tests. If we aren't going to be using them, we should remove them fully instead of leaving unused stuff in the repo for new users to trip over.