### PR TITLE
update std_tomcat function to remove default tomcat apps

### DIFF
--- a/install-labkey.bash
+++ b/install-labkey.bash
@@ -826,11 +826,21 @@ function step_tomcat_service_standard() {
     rm -Rf "${LABKEY_APP_HOME}/src/apache-tomcat-$TOMCAT_VERSION"
     chmod 0700 "${CATALINA_HOME}/conf/Catalina/localhost"
     # remove default tomcat applications
-    rm -Rf "$TOMCAT_INSTALL_HOME/webapps/docs/"
-    rm -Rf "$TOMCAT_INSTALL_HOME/webapps/examples/"
-    rm -Rf "$TOMCAT_INSTALL_HOME/webapps/host-manager/"
-    rm -Rf "$TOMCAT_INSTALL_HOME/webapps/manager/"
-    rm -Rf "$TOMCAT_INSTALL_HOME/webapps/ROOT/"
+    if [[ -d "$TOMCAT_INSTALL_HOME/webapps/docs/" ]]; then
+      rm -Rf "$TOMCAT_INSTALL_HOME/webapps/docs/"
+    fi
+    if [[ -d "$TOMCAT_INSTALL_HOME/webapps/examples/" ]]; then
+      rm -Rf "$TOMCAT_INSTALL_HOME/webapps/examples/"
+    fi
+    if [[ -d "$TOMCAT_INSTALL_HOME/webapps/host-manager/" ]]; then
+      rm -Rf "$TOMCAT_INSTALL_HOME/webapps/host-manager/"
+    fi
+    if [[ -d "$TOMCAT_INSTALL_HOME/webapps/manager/" ]]; then
+      rm -Rf "$TOMCAT_INSTALL_HOME/webapps/manager/"
+    fi
+    if [[ -d "$TOMCAT_INSTALL_HOME/webapps/ROOT/" ]]; then
+      rm -Rf "$TOMCAT_INSTALL_HOME/webapps/ROOT/"
+    fi
     # Create Standard Tomcat Systemd service file -
 
     #create tomcat_lk systemd service file


### PR DESCRIPTION
Small update to remove the default tomcat applications: docs, examples, host-manager, manager and ROOT.