### PR TITLE
Fb mek update

### DIFF
--- a/install-labkey.bash
+++ b/install-labkey.bash
@@ -204,7 +204,7 @@ function step_default_envs() {
   TOMCAT_SSL_PROTOCOL="${TOMCAT_SSL_PROTOCOL:-TLS}"
 
   # Used for Standard Tomcat installs only
-  TOMCAT_VERSION="${TOMCAT_VERSION:-9.0.63}"
+  TOMCAT_VERSION="${TOMCAT_VERSION:-9.0.64}"
   TOMCAT_URL="http://archive.apache.org/dist/tomcat/tomcat-9/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz"
   TOMCAT_USE_PRIVILEGED_PORTS="${TOMCAT_USE_PRIVILEGED_PORTS:-FALSE}"
   TOMCAT_CONTEXT_PATH="${TOMCAT_CONTEXT_PATH:-ROOT}"
@@ -514,7 +514,7 @@ function step_create_app_properties() {
 						server.ssl.key-store-password=${TOMCAT_KEYSTORE_PASSWORD}
 						server.ssl.key-store-type=${TOMCAT_KEYSTORE_FORMAT}
 
-						context.masterEncryptionKey=${LABKEY_MEK}
+						context.EncryptionKey=${LABKEY_MEK}
 						context.serverGUID=${LABKEY_GUID}
 
 						#
@@ -1251,7 +1251,7 @@ SERVERXMLHERE
     <Loader loaderClass="org.labkey.bootstrap.LabkeyServerBootstrapClassLoader" />
 
     <!-- Encryption key for encrypted property store -->
-    <Parameter name="MasterEncryptionKey" value="$LABKEY_MEK" />
+    <Parameter name="EncryptionKey" value="$LABKEY_MEK" />
 
 
 </Context>

--- a/sample_embedded_envs.sh
+++ b/sample_embedded_envs.sh
@@ -12,7 +12,7 @@ export LABKEY_BASE_SERVER_URL="https://localhost"
 #export LABKEY_INSTALL_SKIP_START_LABKEY_STEP=1
 export POSTGRES_SVR_LOCAL="TRUE"
 
-export LABKEY_DIST_URL="https://lk-binaries.s3.us-west-2.amazonaws.com/downloads/release/community/21.11.5/LabKey21.11.5-6-community-embedded.tar.gz"
-export LABKEY_DIST_FILENAME="LabKey21.11.5-6-community-embedded.tar.gz"
-export LABKEY_VERSION="21.11.5"
+export LABKEY_DIST_URL="https://lk-binaries.s3.us-west-2.amazonaws.com/downloads/release/community/22.3.4/LabKey22.3.4-6-community-embedded.tar.gz"
+export LABKEY_DIST_FILENAME="LabKey22.3.4-6-community-embedded.tar.gz"
+export LABKEY_VERSION="22.3.4"
 export LABKEY_DISTRIBUTION="community"

--- a/sample_std_tomcat_envs.sh
+++ b/sample_std_tomcat_envs.sh
@@ -15,9 +15,9 @@ export TOMCAT_INSTALL_HOME="${LABKEY_APP_HOME}/apps/tomcat"
 
 export LABKEY_INSTALL_SKIP_TOMCAT_SERVICE_EMBEDDED_STEP=1
 export TOMCAT_INSTALL_TYPE="Standard"
-export LABKEY_DIST_URL="https://lk-binaries.s3.us-west-2.amazonaws.com/downloads/release/community/21.11.5/LabKey21.11.5-6-community.tar.gz"
-export LABKEY_DIST_FILENAME="LabKey21.11.5-6-community.tar.gz"
-export LABKEY_VERSION="21.11.5"
+export LABKEY_DIST_URL="https://lk-binaries.s3.us-west-2.amazonaws.com/downloads/release/community/22.3.4/LabKey22.3.4-6-community.tar.gz"
+export LABKEY_DIST_FILENAME="LabKey22.3.4-6-community.tar.gz"
+export LABKEY_VERSION="22.3.4"
 export LABKEY_DISTRIBUTION="community"
 export LABKEY_LOG_DIR="/labkey/apps/tomcat/logs"
 export LABKEY_CONFIG_DIR="/labkey/apps/tomcat/config"


### PR DESCRIPTION
- rename master encryption key to encryption key
- update sample setup envs to use 22.3.4