### PR TITLE
fix std tomcat service - not respecting tomcat user

### DIFF
--- a/install-labkey.bash
+++ b/install-labkey.bash
@@ -977,8 +977,8 @@ function step_tomcat_service_standard() {
 				Restart=on-failure
 				RestartSec=2
 
-				User=tomcat
-				Group=tomcat
+				User=$TOMCAT_USERNAME
+				Group=$TOMCAT_USERNAME
 
 				[Install]
 				WantedBy=multi-user.target


### PR DESCRIPTION
 This PR fixes a bug that created installation issues for Standard Tomcat where the tomcat user is something other than tomcat. 
 - required for installations when the OS creates a tomcat user for other purposes etc. 