### PR TITLE
Fb ubuntu 22.04

### DIFF
--- a/install-labkey.bash
+++ b/install-labkey.bash
@@ -695,7 +695,13 @@ function step_postgres_configure() {
     sudo DEBIAN_PRIORITY=critical DEBIAN_FRONTEND=noninteractive apt-get update
     # Postgresql 12 included in Ubuntu 20.04
     if [ "$POSTGRES_SVR_LOCAL" == "TRUE" ]; then
-      sudo DEBIAN_PRIORITY=critical DEBIAN_FRONTEND=noninteractive apt-get -y install postgresql-12
+      if [ "$(platform_version)" == "20.04" ]; then
+        sudo DEBIAN_PRIORITY=critical DEBIAN_FRONTEND=noninteractive apt-get -y install postgresql-12
+      fi
+      # Postgresql 14 included in Ubuntu 22.04
+      if [ "$(platform_version)" == "22.04" ]; then
+        sudo DEBIAN_PRIORITY=critical DEBIAN_FRONTEND=noninteractive apt-get -y install postgresql-14
+      fi
       # Not needed for conical postgresql package
       #if [ ! -f /var/lib/postgresql/12/main/PG_VERSION ]; then
       #  /usr/pgsql-11/bin/postgresql-11-setup initdb
@@ -711,7 +717,12 @@ function step_postgres_configure() {
       sudo systemctl restart postgresql
       console_msg "Postgres Server and Client Installed ..."
     else
-      sudo DEBIAN_PRIORITY=critical DEBIAN_FRONTEND=noninteractive apt-get -y install postgresql-client-12
+      if [ "$(platform_version)" == "20.04" ]; then
+        sudo DEBIAN_PRIORITY=critical DEBIAN_FRONTEND=noninteractive apt-get -y install postgresql-client-12
+      fi
+      if [ "$(platform_version)" == "22.04" ]; then
+        sudo DEBIAN_PRIORITY=critical DEBIAN_FRONTEND=noninteractive apt-get -y install postgresql-client-14
+      fi
       console_msg "Postgres Client Installed ..."
     fi
 

--- a/sample_embedded_envs.sh
+++ b/sample_embedded_envs.sh
@@ -12,7 +12,7 @@ export LABKEY_BASE_SERVER_URL="https://localhost"
 #export LABKEY_INSTALL_SKIP_START_LABKEY_STEP=1
 export POSTGRES_SVR_LOCAL="TRUE"
 
-export LABKEY_DIST_URL="https://lk-binaries.s3.us-west-2.amazonaws.com/downloads/release/community/22.7.0/LabKey22.7.0-1-community-embedded.tar.gz"
-export LABKEY_DIST_FILENAME="LabKey22.7.0-1-community-embedded.tar.gz"
-export LABKEY_VERSION="22.7.0"
+export LABKEY_DIST_URL="https://lk-binaries.s3.us-west-2.amazonaws.com/downloads/release/community/23.11.2/LabKey23.11.2-3-community-embedded.tar.gz"
+export LABKEY_DIST_FILENAME="LabKey23.11.2-3-community-embedded.tar.gz"
+export LABKEY_VERSION="23.11.2"
 export LABKEY_DISTRIBUTION="community"

--- a/sample_std_tomcat_envs.sh
+++ b/sample_std_tomcat_envs.sh
@@ -15,9 +15,9 @@ export TOMCAT_INSTALL_HOME="${LABKEY_APP_HOME}/apps/tomcat"
 
 export LABKEY_INSTALL_SKIP_TOMCAT_SERVICE_EMBEDDED_STEP=1
 export TOMCAT_INSTALL_TYPE="Standard"
-export LABKEY_DIST_URL="https://lk-binaries.s3.us-west-2.amazonaws.com/downloads/release/community/22.7.0/LabKey22.7.0-1-community.tar.gz"
-export LABKEY_DIST_FILENAME="LabKey22.7.0-1-community.tar.gz"
-export LABKEY_VERSION="22.7.0"
+export LABKEY_DIST_URL="https://lk-binaries.s3.us-west-2.amazonaws.com/downloads/release/community/23.11.2/LabKey23.11.2-3-community.tar.gz"
+export LABKEY_DIST_FILENAME="LabKey23.11.2-3-community.tar.gz"
+export LABKEY_VERSION="23.11.2"
 export LABKEY_DISTRIBUTION="community"
 export LABKEY_LOG_DIR="/labkey/apps/tomcat/logs"
 export LABKEY_CONFIG_DIR="/labkey/apps/tomcat/config"
@@ -27,3 +27,4 @@ export TOMCAT_USE_PRIVILEGED_PORTS="TRUE"
 export LABKEY_HTTP_PORT=80
 export LABKEY_HTTPS_PORT=443
 #export TOMCAT_CONTEXT_PATH="labkey"
+export TOMCAT_VERSION="9.0.84"


### PR DESCRIPTION
* Add support for Ubuntu 22.04
* Update sample env scripts with LabKey release v23.11.2 links
* Test LabKey v23.11.2 embedded and standard tomcat installations on Ubuntu v22.04