### PR TITLE
New Features - LabKey start/stop script and on Ubuntu - provide method to install latest Postgresql versions

### DIFF
--- a/install-labkey.bash
+++ b/install-labkey.bash
@@ -654,8 +654,7 @@ function step_postgres_configure() {
     fi
     ;;
 
-  \
-    _rhel)
+  _rhel)
     if [ ! -e "/etc/yum.repos.d/pgdg-redhat-all.repo" ]; then
       sudo yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
       # Disable the built-in PostgreSQL module:
@@ -982,7 +981,7 @@ function step_tomcat_service_standard() {
 
 		HERE_LABKEY_SERVICE_SCRIPT
     ) >"$NewScript"
-      chmod 755 "$NewScript"
+    chmod 755 "$NewScript"
 
     # Create Standard Tomcat Systemd service file -
 


### PR DESCRIPTION
Features added:

- LabKey Service start/stop script - This script prevents Tomcat from being inadvertently stopped during Labkey version upgrades as some version upgrade scripts are implemented via background scripts. If Tomcat is unexpectedly stopped while these scripts are underway or have not started, the LabKey database could be corrupted or be missing important updates.

- On Ubuntu - allow installation of Postgresql versions other than the default version available in the distribution repo 