### PR TITLE
Fb tomcat 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A repository for shell scripts that aid in the installation of LabKey products and services.
 
+## Supported Operating Systems
+
+- AlmaLinux 9
+- Amazon Linux v2
+- RedHat Enterprise Linux 9
+- Ubuntu 20.04 & 22.04
 
 ## LabKey Install Script Usage Examples
 
@@ -156,6 +162,7 @@ The following tables list the available input variables and default values. In t
 | POSTGRES_PROVISION_REMOTE_DB   | Flag to trigger provisioning of remote database - "TRUE" or "FALSE"         | FALSE                                  | no       |
 | POSTGRES_REMOTE_ADMIN_PASSWORD | Postgres Remote Admin Password                                              | NULL                                   | no       |
 | POSTGRES_REMOTE_ADMIN_USER     | Postgres Remote Admin username                                              | postgres_admin                         | no       |
+| POSTGRES_VERSION               | Postgres version to install (two digit value e.g. 16)                       | NULL                                   | no       |
 
 ### SMTP Inputs
 

--- a/install-labkey.bash
+++ b/install-labkey.bash
@@ -448,107 +448,179 @@ function step_create_app_properties() {
     NewFile="${LABKEY_INSTALL_HOME}/application.properties"
     (
       /bin/cat <<-APP_PROPS_HERE
-						# debug=true
-						# trace=true
-
-						server.tomcat.basedir=${TOMCAT_INSTALL_HOME}
 
 						server.port=${LABKEY_HTTPS_PORT}
 
-						spring.main.log-startup-info=true
-
-						spring.main.banner-mode=off
-
-						spring.application.name=labkey
-						server.servlet.application-display-name=labkey
-
-						logging.level.root=WARN
-
-						# custom tomcat group
-						logging.group.tomcat=org.apache.catalina,org.apache.coyote,org.apache.tomcat
-						logging.level.tomcat=${LOG_LEVEL_TOMCAT}
-
-						logging.level.org.apache.coyote.http2=OFF
-
-						# default groups
-						logging.level.web=${LOG_LEVEL_SPRING_WEB}
-						logging.level.sql=${LOG_LEVEL_SQL}
-
-						logging.level.net.sf.ehcache=ERROR
-						logging.level.org.springframework.boot=INFO
-
-						logging.level.org.springframework.jdbc.core=WARN
-						logging.level.org.hibernate.SQL=WARN
-						logging.level.org.jooq.tools.LoggerListener=WARN
-						logging.level.org.springframework.core.codec=WARN
-						logging.level.org.springframework.http=WARN
-						logging.level.org.springframework.web=WARN
-						logging.level.org.springframework.boot.actuate.endpoint.web=WARN
-						logging.level.org.springframework.boot.web.servlet.ServletContextInitializerBeans=WARN
-						logging.level.org.springframework.boot=WARN
-
-						logging.level.org.apache.jasper.servlet.TldScanner=WARN
-						logging.level.org.apache.tomcat.util.digester.Digester=INFO
-
-						context.dataSourceName[0]=jdbc/labkeyDataSource
-						context.driverClassName[0]=org.postgresql.Driver
-						context.url[0]=jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}${POSTGRES_PARAMETERS}
-						context.username[0]=${POSTGRES_USER}
-						context.password[0]=${POSTGRES_PASSWORD}
-
-						server.tomcat.accesslog.directory=${LABKEY_INSTALL_HOME}/logs
-						server.tomcat.accesslog.enabled=true
-						server.tomcat.accesslog.prefix=access
-						server.tomcat.accesslog.suffix=.log
-						server.tomcat.accesslog.rotate=false
-						server.tomcat.accesslog.pattern=%{org.apache.catalina.AccessLog.RemoteAddr}r %l %u %t "%r" %s %b %D %S "%{Referer}i" "%{User-Agent}i" %{LABKEY.username}s %q
-
-						server.http2.enabled=true
 						server.ssl.enabled=true
-
-						server.ssl.ciphers=${TOMCAT_SSL_CIPHERS}
 						server.ssl.enabled-protocols=${TOMCAT_SSL_ENABLED_PROTOCOLS}
 						server.ssl.protocol=${TOMCAT_SSL_PROTOCOL}
-
 						server.ssl.key-alias=${TOMCAT_KEYSTORE_ALIAS}
 						server.ssl.key-store=${TOMCAT_KEYSTORE_BASE_PATH}/${TOMCAT_KEYSTORE_FILENAME}
 						server.ssl.key-store-password=${TOMCAT_KEYSTORE_PASSWORD}
 						server.ssl.key-store-type=${TOMCAT_KEYSTORE_FORMAT}
+						server.ssl.ciphers=${TOMCAT_SSL_CIPHERS}
 
+						# HTTP-only port for servers that need to handle both HTTPS (configure via server.port and server.ssl above) and HTTP
+						#context.httpPort=8080
+
+						# Database connections. All deployments need a labkeyDataSource as their primary database. Add additional external
+						# data sources by specifying the required properties (at least driverClassName, url, username, and password)
+						# with a prefix of context.resources.jdbc.<dataSourceName>.
+						context.resources.jdbc.labkeyDataSource.type=javax.sql.DataSource
+						context.resources.jdbc.labkeyDataSource.driverClassName=org.postgresql.Driver
+						context.resources.jdbc.labkeyDataSource.url=jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}${POSTGRES_PARAMETERS}
+						context.resources.jdbc.labkeyDataSource.username=${POSTGRES_USER}
+						context.resources.jdbc.labkeyDataSource.password=${POSTGRES_PASSWORD}
+						context.resources.jdbc.labkeyDataSource.maxTotal=50
+						context.resources.jdbc.labkeyDataSource.maxIdle=10
+						context.resources.jdbc.labkeyDataSource.maxWaitMillis=120000
+						context.resources.jdbc.labkeyDataSource.accessToUnderlyingConnectionAllowed=true
+						context.resources.jdbc.labkeyDataSource.validationQuery=SELECT 1
+						#context.resources.jdbc.labkeyDataSource.logQueries=true
+						#context.resources.jdbc.labkeyDataSource.displayName=Alternate Display Name
+
+						#context.resources.jdbc.@@extraJdbcDataSource@@.driverClassName=@@extraJdbcDriverClassName@@
+						#context.resources.jdbc.@@extraJdbcDataSource@@.url=@@extraJdbcUrl@@
+						#context.resources.jdbc.@@extraJdbcDataSource@@.username=@@extraJdbcUsername@@
+						#context.resources.jdbc.@@extraJdbcDataSource@@.password=@@extraJdbcPassword@@
+
+						#useLocalBuild#context.webAppLocation=@@pathToServer@@/build/deploy/labkeyWebapp
 						context.EncryptionKey=${LABKEY_MEK}
+
+						# By default, we deploy to the root context path. However, some servers have historically used /labkey or even /cpas
+						#context.contextPath=/labkey
+
+						# Using a legacy context path provides backwards compatibility with old deployments. A typical use case would be to
+						# deploy to the root context (the default) and configure /labkey as the legacy path. GETs will be redirected.
+						# All other methods (POSTs, PUTs, etc) will be handled server-side via a servlet forward.
+						#context.legacyContextPath=/labkey
+
+						# Other webapps to be deployed, most commonly to deliver a set of static files. The context path to deploy into is the
+						# property name after the "context.additionalWebapps." prefix, and the value is the location of the webapp on disk
+						#context.additionalWebapps.firstContextPath=/my/webapp/path
+						#context.additionalWebapps.secondContextPath=/my/other/webapp/path
+
+						#context.oldEncryptionKey=
+						#context.requiredModules=
+						#context.pipelineConfig=/path/to/pipeline/config/dir
 						context.serverGUID=${LABKEY_GUID}
-
-						#
-						# as of time of writing, this cannot be changed via app props but is needed for
-						# management.endpoints.web.base-path below
-						#
-						server.servlet.context-path=/_
-
-						server.error.whitelabel.enabled=false
+						#context.bypass2FA=true
+						#context.workDirLocation=/path/to/desired/workDir
 
 						mail.smtpHost=${SMTP_HOST}
-						mail.smtpUser=${SMTP_USER}
 						mail.smtpPort=${SMTP_PORT}
-						mail.smtpPassword=${SMTP_PASSWORD}
-						mail.smtpAuth=${SMTP_AUTH}
+						mail.smtpUser=${SMTP_USER}
 						mail.smtpFrom=${SMTP_FROM}
+						mail.smtpPassword=${SMTP_PASSWORD}
 						mail.smtpStartTlsEnable=${SMTP_STARTTLS}
+						#mail.smtpSocketFactoryClass=@@smtpSocketFactoryClass@@
+						mail.smtpAuth=${SMTP_AUTH}
 
-						management.endpoints.web.base-path=/
+						# Optional - JMS configuration for remote ActiveMQ message management for distributed pipeline jobs
+						# https://www.labkey.org/Documentation/wiki-page.view?name=jmsQueue
+						#context.resources.jms.ConnectionFactory.type=org.apache.activemq.ActiveMQConnectionFactory
+						#context.resources.jms.ConnectionFactory.factory=org.apache.activemq.jndi.JNDIReferenceFactory
+						#context.resources.jms.ConnectionFactory.description=JMS Connection Factory
+						# Use an in-process ActiveMQ queue
+						#context.resources.jms.ConnectionFactory.brokerURL=vm://localhost?broker.persistent=false&broker.useJmx=false
+						# Use an out-of-process ActiveMQ queue
+						#context.resources.jms.ConnectionFactory.brokerURL=tcp://localhost:61616
+						#context.resources.jms.ConnectionFactory.brokerName=LocalActiveMQBroker
 
+						# Optional - LDAP configuration for LDAP group/user synchronization
+						# https://www.labkey.org/Documentation/wiki-page.view?name=LDAP_sync
+						#context.resources.ldap.ConfigFactory.type=org.labkey.premium.ldap.LdapConnectionConfigFactory
+						#context.resources.ldap.ConfigFactory.factory=org.labkey.premium.ldap.LdapConnectionConfigFactory
+						#context.resources.ldap.ConfigFactory.host=myldap.mydomain.com
+						#context.resources.ldap.ConfigFactory.port=389
+						#context.resources.ldap.ConfigFactory.principal=cn=read_user
+						#context.resources.ldap.ConfigFactory.credentials=read_user_password
+						#context.resources.ldap.ConfigFactory.useTls=false
+						#context.resources.ldap.ConfigFactory.useSsl=false
+						#context.resources.ldap.ConfigFactory.sslProtocol=SSLv3
+
+						#useLocalBuild#spring.devtools.restart.additional-paths=@@pathToServer@@/build/deploy/modules,@@pathToServer@@/build/deploy/embedded/config
+
+						# HTTP session timeout for users - defaults to 30 minutes
+						#server.servlet.session.timeout=30m
+
+
+						#Enable shutdown endpoint
+						management.endpoint.shutdown.enabled=false
+						# turn off other endpoints
 						management.endpoints.enabled-by-default=false
-						management.endpoint.health.enabled=true
-						management.endpoint.info.enabled=true
-
-						management.endpoints.web.exposure.include=health,info
-						management.endpoints.jmx.exposure.exclude=*
+						# allow access via http
+						management.endpoints.web.exposure.include=*
+						# Use a separate port for management endpoints. Required if LabKey is using default (ROOT) context path
+						#management.server.port=@@shutdownPort@@
 
 						management.endpoint.env.keys-to-sanitize=.*user.*,.*pass.*,secret,key,token,.*credentials.*,vcap_services,sun.java.command,.*key-store.*
 
-						info.labkey.version=${LABKEY_VERSION}
-						info.labkey.distribution=${LABKEY_DISTRIBUTION}
+						# Don't show the Spring banner on startup
+						spring.main.banner-mode=off
+						#logging.config=path/to/alternative/log4j2.xml
 
-						server.tomcat.max-threads=50
+						# Optional - JMS configuration for remote ActiveMQ message management for distributed pipeline jobs
+						# https://www.labkey.org/Documentation/wiki-page.view?name=jmsQueue
+						#context.resources.jms.name=jms/ConnectionFactory
+						#context.resources.jms.type=org.apache.activemq.ActiveMQConnectionFactory
+						#context.resources.jms.factory=org.apache.activemq.jndi.JNDIReferenceFactory
+						#context.resources.jms.description=JMS Connection Factory
+						#context.resources.jms.brokerURL=vm://localhost?broker.persistent=false&broker.useJmx=false
+						#context.resources.jms.brokerName=LocalActiveMQBroker
+
+						# Turn on JSON-formatted HTTP access logging to stdout. See issue 48565
+						# https://tomcat.apache.org/tomcat-9.0-doc/config/valve.html#JSON_Access_Log_Valve
+						#jsonaccesslog.enabled=true
+
+						# Optional configuration, modeled on the non-JSON Spring Boot properties
+						# https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html#application-properties.server.server.tomcat.accesslog.buffered
+						#jsonaccesslog.pattern=%h %t %m %U %s %b %D %S "%{Referer}i" "%{User-Agent}i" %{LABKEY.username}s
+						#jsonaccesslog.condition-if=attributeName
+						#jsonaccesslog.condition-unless=attributeName
+
+						# Define one or both of 'csp.report' and 'csp.enforce' to enable Content Security Policy (CSP) headers
+						# Do not copy-and-paste these examples for any production environment without understanding the meaning of each directive!
+
+						# example usage 1 - very strict, disallows 'external' websites, disallows unsafe-inline, but only reports violations (does not enforce)
+
+						#csp.report=\\
+						#    default-src 'self';\\
+						#    connect-src 'self' \${LABKEY.ALLOWED.CONNECTIONS} ;\\
+						#    object-src 'none' ;\\
+						#    style-src 'self' 'unsafe-inline' ;\\
+						#    img-src 'self' data: ;\\
+						#    font-src 'self' data: ;\\
+						#    script-src 'unsafe-eval' 'strict-dynamic' 'nonce-\${REQUEST.SCRIPT.NONCE}';\\
+						#    base-uri 'self' ;\\
+						#    upgrade-insecure-requests ;\\
+						#    frame-ancestors 'self' ;\\
+						#    report-uri https://www.labkey.org/admin-contentsecuritypolicyreport.api?\${CSP.REPORT.PARAMS} ;
+
+						# example usage 2 - less strict but enforces directives, (NOTE: unsafe-inline is still required for many modules)
+
+						#csp.enforce=\\
+						#    default-src 'self' https: ;\\
+						#    connect-src 'self' https: \${LABKEY.ALLOWED.CONNECTIONS};\\
+						#    object-src 'none' ;\\
+						#    style-src 'self' https: 'unsafe-inline' ;\\
+						#    img-src 'self' data: ;\\
+						#    font-src 'self' data: ;\\
+						#    script-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' 'nonce-\${REQUEST.SCRIPT.NONCE}';\\
+						#    base-uri 'self' ;\\
+						#    upgrade-insecure-requests ;\\
+						#    frame-ancestors 'self' ;\\
+						#    report-uri  https://www.labkey.org/admin-contentsecuritypolicyreport.api?\${CSP.REPORT.PARAMS} ;
+
+						# Use a non-temp directory for tomcat
+						server.tomcat.basedir=${TOMCAT_INSTALL_HOME}
+
+						# Enable tomcat access log
+						server.tomcat.accesslog.enabled=true
+						server.tomcat.accesslog.directory=${LABKEY_INSTALL_HOME}/logs
+						server.tomcat.accesslog.pattern=%h %l %u %t "%r" %s %b %D %S %I "%{Referrer}i" "%{User-Agent}i" %{LABKEY.username}s
+
+
 
 			APP_PROPS_HERE
     ) >"$NewFile"

--- a/install-labkey.bash
+++ b/install-labkey.bash
@@ -237,7 +237,6 @@ function step_default_envs() {
   POSTGRES_PROVISION_REMOTE_DB="${POSTGRES_PROVISION_REMOTE_DB:-FALSE}"
   POSTGRES_REMOTE_ADMIN_USER="${POSTGRES_REMOTE_ADMIN_USER:-postgres_admin}"
   POSTGRES_REMOTE_ADMIN_PASSWORD="${POSTGRES_REMOTE_ADMIN_PASSWORD:-}"
-  # two digit Postgresql version other than distro-repo default - this is supported for Ubuntu only - example values "15" or "16"
   POSTGRES_VERSION="${POSTGRES_VERSION:-}"
 
   # smtp env vars

--- a/install-labkey.bash
+++ b/install-labkey.bash
@@ -404,7 +404,7 @@ function step_os_prereqs() {
     # Add adoptium repo
     DEB_JDK_REPO="https://packages.adoptium.net/artifactory/deb/"
     if ! grep -qs "$DEB_JDK_REPO" "/etc/apt/sources.list" "/etc/apt/sources.list.d/"*; then
-      wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/adoptium.gpg > /dev/null
+      wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/adoptium.gpg >/dev/null
       echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
     fi
     sudo DEBIAN_PRIORITY=critical DEBIAN_FRONTEND=noninteractive apt-get update
@@ -677,14 +677,14 @@ function step_postgres_configure() {
     # note this method is required for AMZN linux and supports PG versions 12-15 - v16 not supported by PG repo
     if [[ -z $POSTGRES_VERSION ]]; then
       DEFAULT_POSTGRES_VERSION="15"
-      else
-        DEFAULT_POSTGRES_VERSION=$POSTGRES_VERSION
-        fi
+    else
+      DEFAULT_POSTGRES_VERSION=$POSTGRES_VERSION
+    fi
 
     if [ ! -f "/etc/yum.repos.d/pgdg.repo" ]; then
       NewPGRepoFile="/etc/yum.repos.d/pgdg.repo"
       (
-       /bin/cat <<-PG_REPO_HERE
+        /bin/cat <<-PG_REPO_HERE
 				[pgdg$DEFAULT_POSTGRES_VERSION]
 				name=PostgreSQL $DEFAULT_POSTGRES_VERSION for RHEL/CentOS 7 - x86_64
 				baseurl=https://download.postgresql.org/pub/repos/yum/$DEFAULT_POSTGRES_VERSION/redhat/rhel-7-x86_64
@@ -692,8 +692,8 @@ function step_postgres_configure() {
 				gpgcheck=0
 
 				PG_REPO_HERE
-        ) >"$NewPGRepoFile"
-      fi
+      ) >"$NewPGRepoFile"
+    fi
 
     if [ "$POSTGRES_SVR_LOCAL" == "TRUE" ]; then
       sudo yum clean metadata
@@ -732,9 +732,9 @@ function step_postgres_configure() {
 
     if [[ -z $POSTGRES_VERSION ]]; then
       DEFAULT_POSTGRES_VERSION="15"
-      else
-        DEFAULT_POSTGRES_VERSION=$POSTGRES_VERSION
-        fi
+    else
+      DEFAULT_POSTGRES_VERSION=$POSTGRES_VERSION
+    fi
 
     if [ "$POSTGRES_SVR_LOCAL" == "TRUE" ]; then
       sudo dnf install "postgresql$DEFAULT_POSTGRES_VERSION-server" -y
@@ -767,9 +767,9 @@ function step_postgres_configure() {
 
     if [[ -z $POSTGRES_VERSION ]]; then
       DEFAULT_POSTGRES_VERSION="15"
-      else
-        DEFAULT_POSTGRES_VERSION=$POSTGRES_VERSION
-        fi
+    else
+      DEFAULT_POSTGRES_VERSION=$POSTGRES_VERSION
+    fi
 
     if [ "$POSTGRES_SVR_LOCAL" == "TRUE" ]; then
       sudo dnf install "postgresql$DEFAULT_POSTGRES_VERSION-server" -y

--- a/install-labkey.bash
+++ b/install-labkey.bash
@@ -665,7 +665,8 @@ function step_postgres_configure() {
 
   case "_$(platform)" in
   _amzn)
-    # Install the Postgresql repository RPM:
+    # Install the Postgresql repository RPM
+    # note this method is required for AMZN linux and supports PG versions 12-15 - v16 not supported by PG repo
     if [[ -z $POSTGRES_VERSION ]]; then
       DEFAULT_POSTGRES_VERSION="15"
       else

--- a/install-labkey.bash
+++ b/install-labkey.bash
@@ -390,21 +390,17 @@ function step_os_prereqs() {
   _ubuntu)
     # ubuntu stuff here
     export DEBIAN_FRONTEND=noninteractive
+    sudo DEBIAN_PRIORITY=critical DEBIAN_FRONTEND=noninteractive apt-get update
+    sudo apt-get install -y libtcnative-1 libapr1 wget apt-transport-https gpg
     TOMCAT_LIB_PATH="/usr/lib/x86_64-linux-gnu"
     # Add adoptium repo
     DEB_JDK_REPO="https://packages.adoptium.net/artifactory/deb/"
     if ! grep -qs "$DEB_JDK_REPO" "/etc/apt/sources.list" "/etc/apt/sources.list.d/"*; then
-      wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo apt-key add -
-      NewFile="/etc/apt/sources.list.d/adoptium.list"
-      (
-        /bin/cat <<-ADOPTOPENJDK_APT_REPO
-				deb $DEB_JDK_REPO $(lsb_release -sc) main
-			ADOPTOPENJDK_APT_REPO
-      ) >"$NewFile"
+      wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/adoptium.gpg > /dev/null
+      echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
     fi
-
     sudo DEBIAN_PRIORITY=critical DEBIAN_FRONTEND=noninteractive apt-get update
-    sudo apt-get install -y "$ADOPTOPENJDK_VERSION" libtcnative-1 libapr1
+    sudo apt-get install -y "$ADOPTOPENJDK_VERSION"
     sudo DEBIAN_PRIORITY=critical DEBIAN_FRONTEND=noninteractive apt-get -y -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold" dist-upgrade
     ;;
 

--- a/install-labkey.bash
+++ b/install-labkey.bash
@@ -948,6 +948,9 @@ function step_configure_labkey() {
       if [ -f "${LABKEY_SRC_HOME}/${LABKEY_DIST_DIR}/labkeyServer-${LABKEY_VERSION}.jar" ]; then
         cp -a "${LABKEY_SRC_HOME}/${LABKEY_DIST_DIR}/labkeyServer-${LABKEY_VERSION}.jar" "${LABKEY_INSTALL_HOME}/labkeyServer.jar"
         cp -a "${LABKEY_SRC_HOME}/${LABKEY_DIST_DIR}/VERSION" "${LABKEY_INSTALL_HOME}/VERSION"
+      elif [ -f "${LABKEY_SRC_HOME}/${LABKEY_DIST_DIR}/labkeyServer.jar" ]; then
+        cp -a "${LABKEY_SRC_HOME}/${LABKEY_DIST_DIR}/labkeyServer.jar" "${LABKEY_INSTALL_HOME}/labkeyServer.jar"
+        cp -a "${LABKEY_SRC_HOME}/${LABKEY_DIST_DIR}/VERSION" "${LABKEY_INSTALL_HOME}/VERSION"
       else
         console_msg "ERROR: Something is wrong. Unable copy ${LABKEY_INSTALL_HOME}/labkeyServer.jar, please verify LabKey Version and distribution."
         export ret=1

--- a/sample_tomcat10_embedded_envs.sh
+++ b/sample_tomcat10_embedded_envs.sh
@@ -11,8 +11,8 @@ export LABKEY_BASE_SERVER_URL="https://localhost"
 export POSTGRES_SVR_LOCAL="TRUE"
 export POSTGRES_VERSION="16"
 
-export LABKEY_DIST_URL="https://s3.us-west-2.amazonaws.com/build.labkey.com/LabKey24.3Beta-4-community-embedded.tar.gz"
-export LABKEY_DIST_FILENAME="LabKey24.3Beta-4-community-embedded.tar.gz"
+export LABKEY_DIST_URL="https://s3.us-west-2.amazonaws.com/build.labkey.com/LabKey24.3Beta-15-community-embedded.tar.gz"
+export LABKEY_DIST_FILENAME="LabKey24.3Beta-15-community-embedded.tar.gz"
 export LABKEY_VERSION="24.3-SNAPSHOT"
 export LABKEY_DISTRIBUTION="community"
 
@@ -20,4 +20,4 @@ export LABKEY_DISTRIBUTION="community"
 export TOMCAT_UID="757"
 
 # required for tomcat 10 embedded as the server/ folder will be removed in 24.3.x
-#export LABKEY_STARTUP_DIR="${LABKEY_INSTALL_HOME}/startup}"
+export LABKEY_STARTUP_DIR="${LABKEY_INSTALL_HOME}/startup}"

--- a/sample_tomcat10_embedded_envs.sh
+++ b/sample_tomcat10_embedded_envs.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+#  Sample Env vars to deploy embedded tomcat -
+
+export LABKEY_APP_HOME="/labkey"
+export LABKEY_FILES_ROOT="/labkey/labkey/files"
+export LABKEY_COMPANY_NAME="LabKey"
+export LABKEY_SYSTEM_DESCRIPTION="labkey demo deployment"
+export LABKEY_BASE_SERVER_URL="https://localhost"
+
+export POSTGRES_SVR_LOCAL="TRUE"
+export POSTGRES_VERSION="16"
+
+export LABKEY_DIST_URL="https://s3.us-west-2.amazonaws.com/build.labkey.com/LabKey24.3Beta-4-community-embedded.tar.gz"
+export LABKEY_DIST_FILENAME="LabKey24.3Beta-4-community-embedded.tar.gz"
+export LABKEY_VERSION="24.3-SNAPSHOT"
+export LABKEY_DISTRIBUTION="community"
+
+# Some Rhel based distro's don't like 4 digit UID's
+export TOMCAT_UID="757"
+
+# required for tomcat 10 embedded as the server/ folder will be removed in 24.3.x
+#export LABKEY_STARTUP_DIR="${LABKEY_INSTALL_HOME}/startup}"
+

--- a/sample_tomcat10_embedded_envs.sh
+++ b/sample_tomcat10_embedded_envs.sh
@@ -21,4 +21,3 @@ export TOMCAT_UID="757"
 
 # required for tomcat 10 embedded as the server/ folder will be removed in 24.3.x
 #export LABKEY_STARTUP_DIR="${LABKEY_INSTALL_HOME}/startup}"
-


### PR DESCRIPTION
- Adds support for LabKey release 24.3.x+ and Embedded Tomcat v10
   - Sync application.properties with product 
- Replace CentOS support with AlmaLinux v9
- Update Rhel support to v9
- Add support to choose PostgreSQL version
- Minor README updates
- Add sample installation envs for tomcat10 (LabKey 24.3+) 