### PR TITLE
do not copy labkey jar if it already exists

### DIFF
--- a/install-labkey.bash
+++ b/install-labkey.bash
@@ -968,9 +968,8 @@ function step_configure_labkey() {
     # TODO not sure if this is needed
     chown -R "$TOMCAT_USERNAME":"$TOMCAT_USERNAME" "/work/Tomcat/"
 
-    # strip -embedded from filename to get expected directory name
-
-    if [ -d "${LABKEY_APP_HOME}/src/labkey/${LABKEY_DIST_DIR}" ]; then
+    # skip copy labkeyServer.jar if its already in ${LABKEY_INSTALL_HOME}
+    if [[ -d "${LABKEY_APP_HOME}/src/labkey/${LABKEY_DIST_DIR}" ]] && [[ ! -f "${LABKEY_INSTALL_HOME}/labkeyServer.jar" ]]; then
       # copy jar file to LABKEY_INSTALL_HOME for tomcat_lk.service
       if [ -f "${LABKEY_SRC_HOME}/${LABKEY_DIST_DIR}/labkeyServer-${LABKEY_VERSION}.jar" ]; then
         cp -a "${LABKEY_SRC_HOME}/${LABKEY_DIST_DIR}/labkeyServer-${LABKEY_VERSION}.jar" "${LABKEY_INSTALL_HOME}/labkeyServer.jar"

--- a/sample_tomcat10_embedded_envs.sh
+++ b/sample_tomcat10_embedded_envs.sh
@@ -11,9 +11,9 @@ export LABKEY_BASE_SERVER_URL="https://localhost"
 export POSTGRES_SVR_LOCAL="TRUE"
 export POSTGRES_VERSION="16"
 
-export LABKEY_DIST_URL="https://s3.us-west-2.amazonaws.com/build.labkey.com/LabKey24.3Beta-15-community-embedded.tar.gz"
-export LABKEY_DIST_FILENAME="LabKey24.3Beta-15-community-embedded.tar.gz"
-export LABKEY_VERSION="24.3-SNAPSHOT"
+export LABKEY_DIST_URL="https://s3.us-west-2.amazonaws.com/build.labkey.com/LabKey24.3.4-6-community-embedded.tar.gz"
+export LABKEY_DIST_FILENAME="LabKey24.3.4-6-community-embedded.tar.gz"
+export LABKEY_VERSION="24.3.6"
 export LABKEY_DISTRIBUTION="community"
 
 # Some Rhel based distro's don't like 4 digit UID's
@@ -21,3 +21,6 @@ export TOMCAT_UID="757"
 
 # required for tomcat 10 embedded as the server/ folder will be removed in 24.3.x
 export LABKEY_STARTUP_DIR="${LABKEY_INSTALL_HOME}/startup}"
+export TOMCAT_USE_PRIVILEGED_PORTS="TRUE"
+export LABKEY_HTTP_PORT=80
+export LABKEY_HTTPS_PORT=443


### PR DESCRIPTION
- update sample embedded install vars
- skip copying labkeyServer.jar if it already exists in install directory