### PR TITLE
break out heap size and fix for graal startup issues

### DIFF
--- a/install-labkey.bash
+++ b/install-labkey.bash
@@ -1019,11 +1019,13 @@ function step_tomcat_service_embedded() {
   # Env Vars for tomcat_service file
   # shellcheck disable=SC2046
   JAVA_HOME="$(dirname $(dirname $(readlink -f /etc/alternatives/java)))"
-  JAVA_PRE_JAR_OPS="-Duser.timezone=${TOMCAT_TIMEZONE} -Djava.library.path=${TOMCAT_LIB_PATH} -Djava.awt.headless=true -Xms$JAVA_HEAP_SIZE -Xmx$JAVA_HEAP_SIZE -Djava.security.egd=file:/dev/./urandom"
+  JAVA_HEAP="-Xms$JAVA_HEAP_SIZE -Xmx$JAVA_HEAP_SIZE"
+  JAVA_PRE_JAR_OPS="-Duser.timezone=${TOMCAT_TIMEZONE} -Djava.library.path=${TOMCAT_LIB_PATH} -Djava.awt.headless=true -Djava.security.egd=file:/dev/./urandom"
   JAVA_MID_JAR_OPS="-XX:+HeapDumpOnOutOfMemoryError -XX:+UseContainerSupport -XX:HeapDumpPath=${TOMCAT_TMP_DIR} -Djava.net.preferIPv4Stack=true"
   LABKEY_JAR_OPS="-Dlabkey.home=${LABKEY_INSTALL_HOME} -Dlabkey.log.home=${LABKEY_INSTALL_HOME}/logs -Dlabkey.externalModulesDir=${LABKEY_INSTALL_HOME}/externalModules -Djava.io.tmpdir=${TOMCAT_TMP_DIR}"
   JAVA_FLAGS_JAR_OPS="-Dorg.apache.catalina.startup.EXIT_ON_INIT_FAILURE=true -DsynchronousStartup=true -DterminateOnStartupFailure=true"
-  JAVA_LOG_JAR_OPS="-XX:ErrorFile=${LABKEY_INSTALL_HOME}/logs/error_%p.log -Dlog4j.configurationFile=log4j2.xml -Dpolyglot.engine.resourcePath=${TOMCAT_TMP_DIR}"
+  JAVA_LOG_JAR_OPS="-XX:ErrorFile=${LABKEY_INSTALL_HOME}/logs/error_%p.log -Dlog4j.configurationFile=log4j2.xml"
+  XDG_CACHE_HOME="${TOMCAT_TMP_DIR}"
 
   # Add Tomcat service
   if [ ! -f "/etc/systemd/system/tomcat_lk.service" ]; then
@@ -1040,8 +1042,10 @@ function step_tomcat_service_embedded() {
 				[Service]
 				Type=simple
 				Environment="CATALINA_HOME=${TOMCAT_INSTALL_HOME}"
+				Environment="XDG_CACHE_HOME=${XDG_CACHE_HOME}"
 				Environment="JAVA_HOME=${JAVA_HOME}"
 				Environment="JAVA_PRE_JAR_OPS=${JAVA_PRE_JAR_OPS}"
+				Environment="JAVA_HEAP=${JAVA_HEAP}"
 				Environment="JAVA_MID_JAR_OPS=${JAVA_MID_JAR_OPS}"
 				Environment="LABKEY_JAR_OPS=${LABKEY_JAR_OPS}"
 				Environment="JAVA_LOG_JAR_OPS=${JAVA_LOG_JAR_OPS}"
@@ -1049,7 +1053,7 @@ function step_tomcat_service_embedded() {
 				WorkingDirectory=${LABKEY_INSTALL_HOME}
 				OOMScoreAdjust=-500
 
-				ExecStart=$JAVA_HOME/bin/java \$JAVA_PRE_JAR_OPS \$JAVA_MID_JAR_OPS \$LABKEY_JAR_OPS \$JAVA_LOG_JAR_OPS \$JAVA_FLAGS_JAR_OPS -jar ${LABKEY_INSTALL_HOME}/labkeyServer.jar
+				ExecStart=$JAVA_HOME/bin/java \$JAVA_PRE_JAR_OPS \$JAVA_HEAP \$JAVA_MID_JAR_OPS \$LABKEY_JAR_OPS \$JAVA_LOG_JAR_OPS \$JAVA_FLAGS_JAR_OPS -jar ${LABKEY_INSTALL_HOME}/labkeyServer.jar
 				SuccessExitStatus=0 143
 				Restart=on-failure
 				RestartSec=15


### PR DESCRIPTION
- Break out java heap size to its own VAR so it can be edited easier via other tools
- add VAR for XDG_CACHE_HOME to address startup issue with LabKey v24.7+ 