### PR TITLE
BREAKING: Remove deprecated graal setting and cp command for version file

### DIFF
--- a/install-labkey.bash
+++ b/install-labkey.bash
@@ -980,10 +980,8 @@ function step_configure_labkey() {
       # copy jar file to LABKEY_INSTALL_HOME for tomcat_lk.service
       if [ -f "${LABKEY_SRC_HOME}/${LABKEY_DIST_DIR}/labkeyServer-${LABKEY_VERSION}.jar" ]; then
         cp -a "${LABKEY_SRC_HOME}/${LABKEY_DIST_DIR}/labkeyServer-${LABKEY_VERSION}.jar" "${LABKEY_INSTALL_HOME}/labkeyServer.jar"
-        cp -a "${LABKEY_SRC_HOME}/${LABKEY_DIST_DIR}/VERSION" "${LABKEY_INSTALL_HOME}/VERSION"
       elif [ -f "${LABKEY_SRC_HOME}/${LABKEY_DIST_DIR}/labkeyServer.jar" ]; then
         cp -a "${LABKEY_SRC_HOME}/${LABKEY_DIST_DIR}/labkeyServer.jar" "${LABKEY_INSTALL_HOME}/labkeyServer.jar"
-        cp -a "${LABKEY_SRC_HOME}/${LABKEY_DIST_DIR}/VERSION" "${LABKEY_INSTALL_HOME}/VERSION"
       else
         console_msg "ERROR: Something is wrong. Unable copy ${LABKEY_INSTALL_HOME}/labkeyServer.jar, please verify LabKey Version and distribution."
         export ret=1
@@ -1032,7 +1030,6 @@ function step_tomcat_service_embedded() {
   JAVA_LOG_JAR_OPS="-XX:ErrorFile=${LABKEY_INSTALL_HOME}/logs/error_%p.log -Dlog4j.configurationFile=log4j2.xml"
   JAVA_REFLECTION_JAR_OPS="--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED"
   JAVA_TIMEZONE="-Duser.timezone=${TOMCAT_TIMEZONE}"
-  XDG_CACHE_HOME="${TOMCAT_TMP_DIR}"
   LOCKFILE="$LABKEY_INSTALL_HOME/labkeyUpgradeLockFile"
 
   # Add Tomcat service
@@ -1050,7 +1047,6 @@ function step_tomcat_service_embedded() {
 				[Service]
 				Type=simple
 				Environment="CATALINA_HOME=${TOMCAT_INSTALL_HOME}"
-				Environment="XDG_CACHE_HOME=${XDG_CACHE_HOME}"
 				Environment="JAVA_HOME=${JAVA_HOME}"
 				Environment="JAVA_PRE_JAR_OPS=${JAVA_PRE_JAR_OPS}"
 				Environment="JAVA_HEAP=${JAVA_HEAP}"

--- a/sample_embedded_envs.sh
+++ b/sample_embedded_envs.sh
@@ -12,7 +12,7 @@ export LABKEY_BASE_SERVER_URL="https://localhost"
 #export LABKEY_INSTALL_SKIP_START_LABKEY_STEP=1
 export POSTGRES_SVR_LOCAL="TRUE"
 
-export LABKEY_DIST_URL="https://lk-binaries.s3.us-west-2.amazonaws.com/downloads/release/community/24.11.0/LabKey24.11.0-2-community.tar.gz"
-export LABKEY_DIST_FILENAME="LabKey24.11.0-2-community.tar.gz"
-export LABKEY_VERSION="24.11.0"
+export LABKEY_DIST_URL="https://lk-binaries.s3.us-west-2.amazonaws.com/downloads/release/community/25.3.2/LabKey25.3.2-3-community.tar.gz"
+export LABKEY_DIST_FILENAME="LabKey25.3.2-3-community.tar.gz"
+export LABKEY_VERSION="25.3.2"
 export LABKEY_DISTRIBUTION="community"


### PR DESCRIPTION
Breaking Changes if used to install v24.11.x or older previous versions of Labkey
- Remove XDG_CACHE_HOME which was added for Graal - Graal has been removed in V25.2+  
- Remove cp copy of the deprecated VERSION file which is no longer included in LabKey distributions. 

These were removed as v25.2+ of Labkey no longer requires these settings. 